### PR TITLE
fix VerifyChapPasswd

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -611,7 +611,7 @@ class AuthPacket(Packet):
         if 'CHAP-Challenge' in self:
             challenge = self['CHAP-Challenge'][0]
 
-        return password == md5_constructor("%s%s%s" % (chapid, userpwd, challenge)).digest()
+        return password == md5_constructor(b"%s%s%s" % (chr(chapid).encode('utf-8'), userpwd, challenge)).digest()
 
     def VerifyAuthRequest(self):
         """Verify request authenticator.


### PR DESCRIPTION
The old code causes an error with Python 3.5.2
```
    File "/path_to_module/server.py", line 269, in VerifyChapPasswd
        return password == hashlib.md5("%s%s%s" % (chapid, userpwd, challenge)).digest()
TypeError: Unicode-objects must be encoded before hashing
```